### PR TITLE
Added login lifespan

### DIFF
--- a/auth/token.go
+++ b/auth/token.go
@@ -23,7 +23,7 @@ type TokenClaims struct {
 
 // NewToken issues a new token
 func NewToken(usr string) (Token, time.Time, error) {
-	expiresAt := time.Now().Add(time.Duration(time.Duration(cfg.Config.Security.TokensLifespan) * time.Minute))
+	expiresAt := time.Now().Add(cfg.Config.Security.TokensLifespan)
 
 	claims := &TokenClaims{
 		Usr: usr,
@@ -98,7 +98,7 @@ func (t *Token) Renew() (time.Time, error) {
 }
 
 func renew(claims *TokenClaims) (string, time.Time, error) {
-	expiresAt := time.Now().Add(time.Duration(time.Duration(cfg.Config.Security.TokensLifespan) * time.Minute))
+	expiresAt := time.Now().Add(cfg.Config.Security.TokensLifespan)
 	claims.ExpiresAt = expiresAt.Unix()
 
 	tkn := jwt.NewWithClaims(jwt.SigningMethodHS512, claims)

--- a/auth/token_test.go
+++ b/auth/token_test.go
@@ -36,9 +36,7 @@ func TestValidate(t *testing.T) {
 		signedTkn, err := jwt.NewWithClaims(jwt.SigningMethodHS512, &auth.TokenClaims{
 			Usr: "nefix",
 			StandardClaims: jwt.StandardClaims{
-				ExpiresAt: time.Now().Add(
-					time.Duration(cfg.Config.Security.TokensLifespan) * time.Minute,
-				).Unix(),
+				ExpiresAt: time.Now().Add(cfg.Config.Security.TokensLifespan).Unix(),
 			},
 		}).SignedString([]byte(cfg.Config.Security.TokensSecret))
 		assert.Nil(err)
@@ -60,9 +58,7 @@ func TestValidate(t *testing.T) {
 		signedTkn, err := jwt.NewWithClaims(jwt.SigningMethodHS512, &auth.TokenClaims{
 			Usr: "nefix",
 			StandardClaims: jwt.StandardClaims{
-				ExpiresAt: time.Now().Add(
-					-time.Duration(cfg.Config.Security.TokensLifespan) * time.Minute,
-				).Unix(),
+				ExpiresAt: time.Now().Add(-cfg.Config.Security.TokensLifespan).Unix(),
 			},
 		}).SignedString([]byte(cfg.Config.Security.TokensSecret))
 		assert.Nil(err)
@@ -106,7 +102,7 @@ func TestRenew(t *testing.T) {
 			"created_at": time.Now().Add(-10 * time.Minute),
 		}}).OneTime()
 
-		originalExpirationTime := time.Now().Add(-time.Duration(cfg.Config.Security.TokensLifespan) * time.Minute)
+		originalExpirationTime := time.Now().Add(-cfg.Config.Security.TokensLifespan)
 
 		signedTkn, err := jwt.NewWithClaims(jwt.SigningMethodHS512, &auth.TokenClaims{
 			Usr: "nefix",
@@ -137,7 +133,7 @@ func TestRenew(t *testing.T) {
 
 		mocket.Catcher.NewMock().WithQuery(`SELECT * FROM "users"  WHERE`).WithError(errors.New("testing error")).OneTime()
 
-		originalExpirationTime := time.Now().Add(-time.Duration(cfg.Config.Security.TokensLifespan) * time.Minute)
+		originalExpirationTime := time.Now().Add(-cfg.Config.Security.TokensLifespan)
 
 		signedTkn, err := jwt.NewWithClaims(jwt.SigningMethodHS512, &auth.TokenClaims{
 			Usr: "nefix",

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -3,6 +3,7 @@ package cfg
 import (
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/brainupdaters/drlm-common/pkg/fs"
 	logger "github.com/brainupdaters/drlm-common/pkg/log"
@@ -33,9 +34,10 @@ type DRLMCoreGRPCConfig struct {
 
 // DRLMCoreSecurityConfig is the configuration related with the security of DLRM Core
 type DRLMCoreSecurityConfig struct {
-	BcryptCost     int    `mapstructure:"bcrypt_cost"`
-	TokensLifespan int    `mapstructure:"tokens_lifespan"`
-	TokensSecret   string `mapstructure:"tokens_secret"`
+	BcryptCost     int           `mapstructure:"bcrypt_cost"`
+	TokensSecret   string        `mapstructure:"tokens_secret"`
+	TokensLifespan time.Duration `mapstructure:"tokens_lifespan"`
+	LoginLifespan  time.Duration `mapstructure:"login_lifespan"`
 }
 
 // DRLMCoreDBConfig is the configuration related wtih the DB of the DRLM Core
@@ -99,7 +101,8 @@ func SetDefaults() {
 	})
 	v.SetDefault("security", map[string]interface{}{
 		"bcrypt_cost":     14,
-		"tokens_lifespan": 5,
+		"tokens_lifespan": 5 * time.Minute,
+		"login_lifespan":  240 * time.Hour,
 	})
 	v.SetDefault("db", map[string]interface{}{
 		"host":     "mariadb",

--- a/cfg/cfg_internal_test.go
+++ b/cfg/cfg_internal_test.go
@@ -2,6 +2,7 @@ package cfg
 
 import (
 	"testing"
+	"time"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -21,8 +22,9 @@ func TestSetDefaults(t *testing.T) {
 		assert.Equal("cert/server.key", v.GetString("grpc.key_path"))
 
 		assert.Equal(14, v.GetInt("security.bcrypt_cost"))
-		assert.Equal(5, v.GetInt("security.tokens_lifespan"))
 		assert.Equal("", v.GetString("security.tokens_secret"))
+		assert.Equal(5*time.Minute, v.GetDuration("security.tokens_lifespan"))
+		assert.Equal(240*time.Hour, v.GetDuration("security.login_lifespan"))
 
 		assert.Equal("mariadb", v.GetString("db.host"))
 		assert.Equal(3306, v.GetInt("db.port"))

--- a/cfg/cfg_test.go
+++ b/cfg/cfg_test.go
@@ -2,6 +2,7 @@ package cfg_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/brainupdaters/drlm-core/cfg"
 
@@ -20,8 +21,9 @@ func assertCfg(t *testing.T) {
 	assert.Equal("cert/server.key", cfg.Config.GRPC.KeyPath)
 
 	assert.Equal(14, cfg.Config.Security.BcryptCost)
-	assert.Equal(5, cfg.Config.Security.TokensLifespan)
 	assert.Equal("", cfg.Config.Security.TokensSecret)
+	assert.Equal(5*time.Minute, cfg.Config.Security.TokensLifespan)
+	assert.Equal(240*time.Hour, cfg.Config.Security.LoginLifespan)
 
 	assert.Equal("mariadb", cfg.Config.DB.Host)
 	assert.Equal(3306, cfg.Config.DB.Port)

--- a/transport/grpc/grpc_internal_test.go
+++ b/transport/grpc/grpc_internal_test.go
@@ -76,7 +76,7 @@ func TestCheckAuth(t *testing.T) {
 		signedTkn, err := jwt.NewWithClaims(jwt.SigningMethodHS512, &auth.TokenClaims{
 			Usr: "nefix",
 			StandardClaims: jwt.StandardClaims{
-				ExpiresAt: time.Now().Add(time.Duration(cfg.Config.Security.TokensLifespan) * time.Minute).Unix(),
+				ExpiresAt: time.Now().Add(cfg.Config.Security.TokensLifespan).Unix(),
 			},
 		}).SignedString([]byte(cfg.Config.Security.TokensSecret))
 		assert.Nil(err)

--- a/transport/grpc/user_test.go
+++ b/transport/grpc/user_test.go
@@ -129,7 +129,7 @@ func TestUserTokenRenew(t *testing.T) {
 			"created_at": time.Now().Add(-10 * time.Minute),
 		}}).OneTime()
 
-		originalExpirationTime := time.Now().Add(-time.Duration(cfg.Config.Security.TokensLifespan) * time.Minute)
+		originalExpirationTime := time.Now().Add(-cfg.Config.Security.TokensLifespan)
 
 		signedTkn, err := jwt.NewWithClaims(jwt.SigningMethodHS512, &auth.TokenClaims{
 			Usr: "nefix",

--- a/transport/grpc/user_test.go
+++ b/transport/grpc/user_test.go
@@ -132,7 +132,8 @@ func TestUserTokenRenew(t *testing.T) {
 		originalExpirationTime := time.Now().Add(-cfg.Config.Security.TokensLifespan)
 
 		signedTkn, err := jwt.NewWithClaims(jwt.SigningMethodHS512, &auth.TokenClaims{
-			Usr: "nefix",
+			Usr:         "nefix",
+			FirstIssued: originalExpirationTime,
 			StandardClaims: jwt.StandardClaims{
 				ExpiresAt: originalExpirationTime.Unix(),
 				IssuedAt:  originalExpirationTime.Add(-1 * time.Minute).Unix(),


### PR DESCRIPTION
- Now a login has a lifespan. If a token that has exceeded this lifespan is tried to be renewed, it's going to fail.
- Now the token lifespan setting has a time.Duration type